### PR TITLE
Add three data loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,11 @@ tmp*.txt
 *.nsys-rep
 *.ncu-rep
 logs/
+
+
+# datasets
+chameleon-llm
+ToolQA
+CREATOR
+apibench_data
+ToolAlpaca

--- a/multi_node/benchmarks/benchmark_workload_gen.py
+++ b/multi_node/benchmarks/benchmark_workload_gen.py
@@ -25,6 +25,9 @@ from dataclasses import dataclass
 import logging
 from datasets import load_dataset
 import re
+from . import chameleon
+from . import toolqa
+import os
 
 ReActWorkloadEx1 = """
 Question: What is the elevation range for the area that the eastern sector of the Colorado orogeny extends into?
@@ -669,6 +672,7 @@ class LoogleOracle(CustomRuntimeSelector):
         else:
             return random.randint(0, self.num_nodes - 1)
 
+
 class MultiDomainToolBenchDataLoader(DataLoader):
     def __init__(
         self,
@@ -855,3 +859,268 @@ class TBMultiDomainOracle(CustomRuntimeSelector):
             return self.tbl[tool]
         else:
             return random.randint(0, self.num_nodes - 1)
+
+
+class ChameleonTabMWPLoader(DataLoader):
+    """DataLoader for Chameleon + TabMWP dataset"""
+
+    def __init__(self, data_path: str, 
+                 tokenizer: PreTrainedTokenizer):
+        super().__init__(data_path, None, None, tokenizer)
+        self.data = self.read_data(data_path)
+
+    def read_data(self, data_path: str):
+        data = []
+        with open(data_path, "r") as f:
+            for line in f.readlines():
+                data.append(json.loads(line))
+        return data
+
+    def generate_module_prediction_request(self, sample):
+        return {
+            'text': chameleon.prompt_policy.prompt.strip() + '\n\n' + sample['modules:input'],
+            'sampling_params': {
+                'temperature': 0.0,
+                'max_new_tokens': len(self.tokenizer(str(sample['modules:output'])).input_ids),
+            },
+        }
+
+    def generate_row_lookup_request(self, sample):
+        return {
+            'text': chameleon.prompt_rl.prompt.strip() + '\n\n' + sample['row_lookup:input'],
+            'sampling_params': {
+                'temperature': 0.0,
+                'max_new_tokens': len(self.tokenizer(sample['row_lookup:output']).input_ids),
+            },
+        }
+
+    def generate_column_lookup_request(self, sample):
+        return {
+            'text': chameleon.prompt_cl.prompt.strip() + '\n\n' + sample['column_lookup:input'],
+            'sampling_params': {
+                'temperature': 0.0,
+                'max_new_tokens': len(self.tokenizer(sample['column_lookup:output']).input_ids),
+            },
+        }
+    
+    def generate_table_verbalizer_request(self, sample):
+        return {
+            'text': chameleon.prompt_tv.prompt.strip() + '\n\n' + sample['table_verbalizer:input'],
+            'sampling_params': {
+                'temperature': 0.0,
+                'max_new_tokens': len(self.tokenizer(sample['table_verbalizer:output']).input_ids),
+            },
+        }
+    
+    def generate_knowledge_retrieval_request(self, sample):
+        return {
+            'text': chameleon.prompt_kr.prompt.strip() + '\n\n' + sample['knowledge_retrieval:input'],
+            'sampling_params': {
+                'temperature': 0.0,
+                'max_new_tokens': len(self.tokenizer(sample['knowledge_retrieval:output']).input_ids),
+            },
+        }
+
+    def generate_program_generator_request(self, sample):
+        if sample['example']['choices']:
+            demo_prompt = chameleon.prompt_pg.prompt_choice.strip()
+        else:
+            demo_prompt = chameleon.prompt_pg.prompt_free.strip()
+        return {
+            'text': demo_prompt + '\n\n' + sample['program_generator:input'],
+            'sampling_params': {
+                'temperature': 0.0,
+                'max_new_tokens': len(self.tokenizer(sample['program_generator:output']).input_ids),
+            },
+        }
+
+    def generate_program_generator_verifier_request(self, sample):
+        if sample['example']['choices']:
+            demo_prompt = chameleon.prompt_pg.prompt_choice.strip()
+        else:
+            demo_prompt = chameleon.prompt_pg.prompt_free.strip()
+        return {
+            'text': demo_prompt + '\n\n' + sample['program_generator_and_verifier:input'],
+            'sampling_params': {
+                'temperature': 0.0,
+                'max_new_tokens': len(self.tokenizer(sample['program_generator_and_verifier:output']).input_ids),
+            },
+        }
+    
+    def generate_solution_generator_request(self, sample):
+        if sample['example']['choices']:
+            demo_prompt = chameleon.prompt_sg.prompt_choice.strip()
+        else:
+            demo_prompt = chameleon.prompt_sg.prompt_free.strip()
+        return {
+            'text': demo_prompt + '\n\n' + sample['solution_generator:input'],
+            'sampling_params': {
+                'temperature': 0.0,
+                'max_new_tokens': len(self.tokenizer(f"The answer is {sample['solution_generator:output']}.").input_ids),
+            },
+        }
+
+    def generate_workload(self, k: int = None):
+        requests = []
+        random.shuffle(self.data)
+        for i, sample in enumerate(self.data):
+            if k is not None and len(requests) >= k:
+                break
+            # handle predict module requests
+            requests.append(self.generate_module_prediction_request(sample))
+            
+            modules = sample['modules:output']
+            if "row_lookup" in modules and sample['row_lookup:input']:
+                requests.append(self.generate_row_lookup_request(sample))
+            if "column_lookup" in modules and sample['column_lookup:input']:
+                requests.append(self.generate_column_lookup_request(sample))
+            if "table_verbalizer" in modules:
+                requests.append(self.generate_table_verbalizer_request(sample))
+            if "knowledge_retrieval" in modules:
+                requests.append(self.generate_knowledge_retrieval_request(sample))
+            if "program_generator" in modules:
+                requests.append(self.generate_program_generator_request(sample))
+            if "program_generator_and_verifier" in modules:
+                requests.append(self.generate_program_generator_verifier_request(sample))
+            if "solution_generator" in modules:
+                requests.append(self.generate_solution_generator_request(sample))
+
+        self.add_input_token_ids_to_workload(requests)
+        return requests[:k]
+    
+
+class CreatorMATHLoader(DataLoader):
+    """DataLoader for Creator + MATH dataset.
+    Since the agents depend on the previous steps, 
+    we use the same tool and error message for all samples."""
+
+    tool = """```python
+from sympy import symbols, solve
+
+def solve_equations():
+    \"\"\"
+    Solves the system of equations 3p + 4q = 8 and 4p + 3q = 13 using sympy.
+    Returns: The value of q that satisfies both equations.
+    \"\"\"
+    p, q = symbols('p q')
+    eq1 = 3*p + 4*q - 8
+    eq2 = 4*p + 3*q - 13
+    solution = solve((eq1, eq2), (p, q))
+    return solution[q]
+
+# Call the function to solve the equations
+q = solve_equations()
+
+# Print the answer
+print("Final Answer:", q)"""
+
+    error = """Traceback (most recent call last):
+  File "code_exec/tmp0.py", line 15, in <module>
+    z_over_y = solve_equations()
+  File "code_exec/tmp0.py", line 12, in solve_equations
+    return solution[z] / solution[y]
+KeyError: z"""
+
+    def __init__(self, data_path: str, 
+                 tokenizer: PreTrainedTokenizer):
+        super().__init__(data_path, None, None, tokenizer)
+        self.data = self.read_data(os.path.join(data_path, 'dataset'))
+        with open(os.path.join(data_path, 'prompt_lib/prompt_CREATOR_creation.md'), 'r') as f:
+            self.create_prompt = f.read()
+        with open(os.path.join(data_path, 'prompt_lib/prompt_CREATOR_decision.md'), 'r') as f:
+            self.decide_prompt = f.read()
+        with open(os.path.join(data_path, 'prompt_lib/prompt_rectification.md'), 'r') as f:
+            self.correct_prompt = f.read()
+
+    def read_data(self, data_path: str):
+        data = []
+        for file in os.listdir(data_path):
+            with open(os.path.join(data_path, file), "r") as f:
+                for line in f:
+                    if line.strip():
+                        data.append(json.loads(line))
+        return data
+
+    def generate_workload(self, k: int = None):
+        requests = []
+        random.shuffle(self.data)
+        for i, sample in enumerate(self.data):
+            if k is not None and len(requests) >= k:
+                break
+            requests.append({
+                'text': self.create_prompt.replace('==qst==', sample['question']),
+                'sampling_params': {
+                    'temperature': 0.0,
+                    'max_new_tokens': 30,
+                },
+            })
+            requests.append({
+                'text': self.decide_prompt.replace('==qst==', sample['question']).replace(
+                    '==tool==', self.tool
+                ),
+                'sampling_params': {
+                    'temperature': 0.0,
+                    'max_new_tokens': 30,
+                },
+            })
+            requests.append({
+                'text': self.correct_prompt.replace('==qst==', sample['question']).replace(
+                    '==ori==', self.tool
+                ).replace('==err==', self.error),
+                'sampling_params': {
+                    'temperature': 0.0,
+                    'max_new_tokens': 30,
+                },
+            })
+        
+        self.add_input_token_ids_to_workload(requests)
+        return requests[:k]
+    
+
+class ToolQALoader(DataLoader):
+    """DataLoader for ToolQA dataset.
+    
+    The ToolQA dataset consists of two level of difficulty: easy and hard.
+    In this class, workload is generated randomly from both levels.
+    
+    The original ToolQA paper uses multi-step reasoning (with langchain).
+    Since we are not using actual LLMs, we generate the request of first step."""
+
+    scratchpad = """\nThought 1:\n"""
+
+    def __init__(self, data_path: str, 
+                 tokenizer: PreTrainedTokenizer, ):
+        super().__init__(data_path, None, None, tokenizer)
+        self.data = self.read_data(data_path)
+
+    def read_data(self, data_path: str):
+        data = []
+        for hardness in ['easy', 'hard']:
+            for file in os.listdir(os.path.join(data_path, hardness)):
+                with open(os.path.join(data_path, hardness, file), "r") as f:
+                    for line in f:
+                        if line.strip():
+                            example = json.loads(line)
+                            example['hardness'] = hardness
+                            data.append(example)
+        return data
+
+    def generate_workload(self, k: int = None):
+        requests = []
+        for i, sample in enumerate(self.data):
+            if k is not None and i >= k:
+                break
+            examples = toolqa.TOOLQA_EASY8 if sample['hardness'] == 'easy' else toolqa.TOOLQA_HARD3
+            requests.append({
+                'text': toolqa.REACT_INSTRUCTION.format(examples=examples, 
+                                                 question=sample['question'], 
+                                                 scratchpad=self.scratchpad),
+                'sampling_params': {
+                    'temperature': 0.0,
+                    'max_new_tokens': 30,
+                },
+            })
+        
+        self.add_input_token_ids_to_workload(requests)
+        return requests
+

--- a/multi_node/benchmarks/chameleon/__init__.py
+++ b/multi_node/benchmarks/chameleon/__init__.py
@@ -1,0 +1,12 @@
+"""Prompts for the Chameleon TabWMP dataset."""
+
+from . import prompt_cl
+from . import prompt_kr
+from . import prompt_pg
+from . import prompt_policy
+from . import prompt_rl
+from . import prompt_sg
+from . import prompt_tv
+
+__all__ = ['prompt_cl', 'prompt_kr', 'prompt_pg', 'prompt_policy', 'prompt_rl',
+           'prompt_sg', 'prompt_tv']

--- a/multi_node/benchmarks/chameleon/prompt_cl.py
+++ b/multi_node/benchmarks/chameleon/prompt_cl.py
@@ -1,0 +1,107 @@
+
+prompt = """
+Read the following question and table. Each row is separated by a newline ('\n') and each column is separated by a vertical bar ('|'). Return the simplified table that only remains the columns that are relevant to the question. If all columns are relevant, return the original table.
+
+Question: In preparation for graduation, some teachers and students volunteered for the various graduation committees. How many people are on the music committee?
+
+Table:
+Committee | Students | Teachers
+Program | 5 | 17
+Ticket | 20 | 5
+Music | 20 | 15
+Schedule | 15 | 20
+Food | 18 | 2
+
+Simplified Table:
+Committee | Students | Teachers
+Program | 5 | 17
+Ticket | 20 | 5
+Music | 20 | 15
+Schedule | 15 | 20
+Food | 18 | 2
+
+Question: Look at the following schedule. When does Recess end?
+
+Table:
+Subject | Begin | End
+Recess | 6:15 A.M. | 7:20 A.M.
+Orchestra | 7:30 A.M. | 8:40 A.M.
+Art | 8:45 A.M. | 9:35 A.M.
+Handwriting | 9:45 A.M. | 10:20 A.M.
+Gym | 10:30 A.M. | 11:15 A.M.
+Choir | 11:20 A.M. | 12:25 P.M.
+Science | 12:35 P.M. | 1:35 P.M.
+Reading | 1:40 P.M. | 2:50 P.M.
+
+Simplified Table:
+Subject | End
+Recess | 7:20 A.M.
+Orchestra | 8:40 A.M.
+Art | 9:35 A.M.
+Handwriting | 10:20 A.M.
+Gym | 11:15 A.M.
+Choir | 12:25 P.M.
+Science | 1:35 P.M.
+Reading | 2:50 P.M.
+
+Question: Derek's Candies has been studying how much chocolate people have been eating in different countries. Which country consumed the least chocolate per capita in 2002?
+
+Table:
+Country | 2002 | 2005
+Denmark | 9 | 8
+Australia | 4 | 5
+Sweden | 8 | 7
+Belgium | 8 | 11
+
+Simplified Table:
+Country | 2002
+Denmark | 9
+Australia | 4
+Sweden | 8
+Belgium | 8
+
+Question: Look at the following schedule. Amy is at Oakland. If she wants to arrive at Danville at 3.15 P.M., what time should she get on the train?
+
+Table:
+Oakland | 7:45 A.M. | 8:00 A.M. | 10:00 A.M. | 11:45 A.M. | 12:15 P.M.
+Danville | 11:15 A.M. | 11:30 A.M. | 1:30 P.M. | 3:15 P.M. | 3:45 P.M.
+
+Simplified Table:
+Oakland | 11:45 A.M.
+Danville | 3:15 P.M.
+
+Question: Sixth graders at Campbell Middle School are taught in classes of various sizes. How many more students are in Mr. East's class than Mr. Center's class?
+
+Table:
+Teacher | Girls | Boys
+Mr. Center | 16 | 10
+Miss West | 17 | 20
+Mrs. South | 16 | 16
+Ms. North | 11 | 9
+Mr. East | 12 | 17
+
+Simplified Table:
+Teacher | Girls | Boys
+Mr. Center | 16 | 10
+Mr. East | 12 | 17
+
+Question: A researcher recorded the number of cows on each farm in the county. How many farms have at least 4 cows but fewer than 46 cows?
+
+Table:
+Stem | Leaf 
+0 | 1, 4, 7
+1 | 2, 4, 5
+2 | 0, 3
+3 | 
+4 | 0, 1, 5, 8, 9
+
+Simplified Table:
+Stem | Leaf 
+0 | 1, 4, 7
+1 | 2, 4, 5
+2 | 0, 3
+3 | 
+4 | 0, 1, 5, 8, 9
+
+Read the following question and table. Each row is separated by a newline ('\n') and each column is separated by a vertical bar ('|'). Return the simplified table that only remains the columns that are relevant to the question. If all columns are relevant, return the original table.
+"""

--- a/multi_node/benchmarks/chameleon/prompt_kr.py
+++ b/multi_node/benchmarks/chameleon/prompt_kr.py
@@ -1,0 +1,71 @@
+# 
+prompt = """
+Read the following table and question, and generate the domain-specific knowledge as the context information that could be helpful for answering the question.
+
+Table:
+x | y
+10 | 15
+11 | 9
+12 | 2
+
+Question: The table shows a function. Is the function linear or nonlinear?
+
+Knowledge:
+- A linear function is a function whose graph is a straight line.
+- A nonlinear function is a function whose graph is not a straight line.
+- The equation of a linear function is y = mx + b, where m is the slope and b is the y-intercept.
+- The equation of a nonlinear function is not y = mx + b.
+
+Table: Dog | Weight change (oz.)
+Sprinkles | 5
+Champ | -6
+
+Question: Austen has two dogs, Sprinkles and Champ. He is concerned because Sprinkles keeps eating Champ's food. Austen asks their vet how much each dog's weight has changed since their last visit. Which dog's weight has changed the most?
+
+Knowledge:
+- This table shows the weight change (in ounces) for two dogs, Sprinkles and Champ.
+- The dog whose weight has changed the most is the one with the highest (positive or negative) weight change.
+
+Table:
+Stem | Leaf 
+1 | 6, 7, 8
+2 | 1, 4, 6, 7
+3 | 
+4 | 1, 2, 5, 7, 7, 9
+5 | 1, 8, 9
+
+Question: Ms. Bradford reported her students' scores on the most recent quiz. How many students scored exactly 17 points?
+
+Knowledge:
+- This is a stem-leaf plot, where each data value is split into a "stem" (the first digit or digits) and a "leaf" (usually the last digit).
+- The stems represent the tens digit of the data values, while the leaves represent the ones digit.
+- The data value 17 would be represented as stem 1 and leaf 7.
+
+Table: 
+ | Fly | Read minds
+Forgetful | 2 | 4
+Lazy | 2 | 2
+
+Question: A creative writing class compiled a list of their favorite superheroes. They listed each superhero's superpower and personality flaw. What is the probability that a randomly selected superhero is lazy and can read minds? Simplify any fractions.
+
+Knowledge:
+- This table shows a two-way frequency table, which is used to show the relationship between two variables.
+- The probability of an event is calculated by dividing the number of favorable outcomes by the total number of outcomes.
+
+Table: 
+Stem | Leaf 
+3 | 3
+4 | 1, 4
+5 | 6, 7
+6 | 6
+7 | 2
+
+Question: The receptionist at a doctor's office kept track of each patient's wait time. What is the shortest wait time?
+
+Knowledge:
+- This is a stem-leaf plot, which is used to organize numerical data. 
+- The stems represent the tens digit of the data values, while the leaves represent the ones digit.
+- The shortest wait time is represented by the stem with the lowest value and the leaf with the lowest value within that stem.
+
+Read the following table and question, and generate the domain-specific knowledge as the context information that could be helpful for answering the question.
+"""

--- a/multi_node/benchmarks/chameleon/prompt_pg.py
+++ b/multi_node/benchmarks/chameleon/prompt_pg.py
@@ -1,0 +1,164 @@
+
+prompt_choice ="""
+Read the following table and then write Python code to answer a question:
+
+Price | Quantity demanded | Quantity supplied
+$895 | 21,000 | 3,400
+$945 | 17,200 | 7,400
+$995 | 13,400 | 11,400
+$1,045 | 9,600 | 15,400
+$1,095 | 5,800 | 19,400
+
+Look at the table. Then answer the question. At a price of $995, is there a shortage or a surplus? Please select from the following options: ['shortage', 'surplus'].
+
+# Python Code, return 'ans'. Make sure that 'ans' is a string selected from the options in the question
+quantity_demanded_at_price_955 = 13400
+quantity_supplied_at_price_955 = 11400
+if quantity_demanded_at_price_955 > quantity_supplied_at_price_955:
+    ans = 'shortage'
+else:
+    ans = 'surplus'
+
+Read the following table regarding Ferry fares and then write Python code to answer a question:
+
+Ferry | Bicycle | Car
+Ocracoke | $3 | $15
+Fauntleroy-Vashon | $5 | $15
+
+For an economics project, Abby determined the cost of ferry rides for bicycles and cars. Which charges more for a bicycle, the Ocracoke ferry or the Fauntleroy-Vashon ferry? Please select from the following options: ['Ocracoke', 'Fauntleroy-Vashon'].
+
+# Python Code, return 'ans'. Make sure that 'ans' is a string selected from the options in the question
+bicycle_cost_ocracoke = 3
+bicycle_cost_fauntleroy_vashon = 5
+if bicycle_cost_ocracoke > bicycle_cost_fauntleroy_vashon:
+    ans = 'Ocracoke'
+else:
+    ans = 'Fauntleroy-Vashon'
+    
+Read the following table and then write Python code to answer a question:
+
+toy guitar | $32.42
+toy piano | $10.55
+model railroad set | $65.51
+toy rocket | $80.93
+chess board | $15.76
+
+Cody has $49.50. Does he have enough to buy a toy guitar and a chess board? Please select from the following options: ['yes', 'no'].
+
+# Python Code, return 'ans'. Make sure that 'ans' is a string selected from the options in the question
+toy_guitar_price = 32.42
+chess_board_price = 15.76
+total_money = 49.50
+if total_money > toy_guitar_price + chess_board_price:
+    ans = 'yes'
+else:
+    ans = 'no'
+
+Read the following table regarding Train schedule and then write Python code to answer a question:
+
+Location | Arrive | Depart
+Richmond | 8:05 A.M. | 8:10 A.M.
+Weston | 9:00 A.M. | 9:15 A.M.
+Fairview | 10:15 A.M. | 10:25 A.M.
+Newton | 11:15 A.M. | 11:30 A.M.
+Milford | 12:35 P.M. | 12:45 P.M.
+Greenpoint | 1:45 P.M. | 1:55 P.M.
+Georgetown | 2:35 P.M. | 2:40 P.M.
+
+Look at the following schedule. When does the train arrive at Milford? Please select from the following options: ['12:35 P.M.', '10:15 A.M.', '2:35 P.M.', '8:05 A.M.'].
+
+# Python Code, return 'ans'. Make sure that 'ans' is a string selected from the options in the question
+schedule = {
+   'Richmond': '8:05 A.M.',
+   'Weston': '9:00 A.M.',
+   'Fairview': '10:15 A.M.',
+   'Newton': '11:15 A.M.',
+   'Milford': '12:35 P.M.',
+   'Greenpoint': '1:45 P.M.',
+   'Georgetown': '2:35 P.M.'
+}
+ans = schedule['Milford']
+"""
+
+prompt_free ="""
+Read the following table regarding Coin collections and then write Python code to answer a question:
+
+Name | Number of coins
+Shelby | 81
+Oliver | 84
+Jamal | 78
+Vince | 81
+Abby | 79
+Farid | 77
+Tara | 85
+Krysta | 83
+
+Some friends discussed the sizes of their coin collections. What is the mean of the numbers?
+
+# Python Code, return 'ans'. Make sure that 'ans' is a number
+number_of_coins_for_different_person = [81, 84, 78, 81, 79, 77, 85, 83]
+ans = sum(number_of_coins_for_different_person) / len(number_of_coins_for_different_person)
+
+Read the following table regarding Cans of food collected and then write Python code to answer a question:
+
+Name | Number of cans of food
+Martin | 18
+Cole | 11
+Todd | 24
+Jasper | 4
+Alan | 22
+Percy | 18
+Bridget | 6
+
+Martin's class recorded how many cans of food each student collected for their canned food drive. What is the median of the numbers?
+
+# Python Code, return 'ans'. Make sure that 'ans' is a number
+cans = [18, 11, 24, 4, 22, 18, 6]
+cans = sorted(cans)
+middle1 = (len(cans) - 1) // 2
+middle2 = len(cans) // 2
+ans = (cans[middle1] + cans[middle2]) / 2
+
+Read the following table regarding Number of houses sold and then write Python code to answer a question:
+
+Town | Number of houses sold
+Seaside | 900
+Summerfield | 600
+Oakdale | 550
+Greenwood | 370
+Fairview | 440
+Other | 420
+
+A real estate agent evaluated the number of houses sold this year in each town in Washington County. What fraction of houses sold in Washington County were in Greenwood? Simplify your answer.
+
+# Python Code, return 'ans'. Make sure that 'ans' is a number
+houses_sold = [900, 600, 550, 370, 440, 420]
+houses_sold_in_Stamford = houses_sold[3]
+total_houses_sold = sum(houses_sold)
+ans = houses_sold_in_Stamford / total_houses_sold
+
+Read the following table regarding Bricks per building and then write Python code to answer a question:
+
+Stem | Leaf 
+2 | 5, 7, 8
+3 | 
+4 | 
+5 | 8
+6 | 8
+7 | 7
+8 | 1, 1, 9
+9 | 0
+
+The architecture student counted the number of bricks in each building in his neighborhood. How many buildings have at least 20 bricks but fewer than 70 bricks? (Unit: buildings)
+
+# Python Code, return 'ans'. Make sure that 'ans' is a number
+stem_leaf = {2: [5, 7, 8], 3: [], 4: [], 5: [8], 6: [8], 7: [7], 8: [1, 1, 9], 9: [0]}
+ans = 0
+for stem in stem_leaf.keys():
+    for leaf in stem_leaf[stem]:
+        if 20 <= stem * 10 + leaf <= 70:
+            ans += 1
+"""
+
+
+

--- a/multi_node/benchmarks/chameleon/prompt_policy.py
+++ b/multi_node/benchmarks/chameleon/prompt_policy.py
@@ -1,0 +1,221 @@
+
+prompt = """
+You need to act as a policy model, that given a question and a modular set, determines the sequence of modules that can be executed sequentially can solve the question.
+
+The modules are defined as follows:
+
+- Program_Generator: This module generats a python program that can solve the given question. It takes in the question and possible context and produces a program that can be executed by the "Program_Executor" module. Normally, we consider using "Program_Generator" when the questions and contexts involve complex computation, such as arithmetic operations over multiple numbers, or when the questions involve complex logical operations, such as "if-else" statements.
+
+- Program_Verifier: This module verifies whether the generated program from "Program_Generator" is valid and error-free. It checks for syntax errors, logical errors, and other potential issues that may arise during program execution.
+
+- Program_Executor: This module executes the generated program from "Program_Generator" and produces an output that can be further processed by other modules, such as "Question_Answering". 
+
+- Row_Lookup: This module returns the simplified table that only remains the rows that are relevant to the question. It takes in the question and a table and returns the simplified table. If all rows are relevant or there are only three rows or less, return the original table. Normally, we only consider using "Row_Lookup" when the table involves more than three rows and the question only requires a small number of rows to answer the question.
+
+- Column_Lookup: This module returns the simplified table that only remains the columns that are relevant to the question. It takes in the question and a table and returns the simplified table. If all columns are relevant or there are only two columns, return the original table. Normally, we consider using "Column_Lookup" when the table involves more than two columns and the question only requires a small number of columns to answer the question. 
+
+- Table_Verbalizer: This module converts the table to a description that can be easily understood by the downstream modules, like "Program_Generator", "Solution_Generator", "Question_Answering". Normally, we consider using "Table_Verbalizer" when the table involves a small number of rows and columns and the table is domain-specific, such as steam-and-leaf plots, function tables, etc.
+
+- Knowledge_Retrieval: This module retrieves domain-specific knowledge for the given question and table. Normally, we consider using "Knowledge_Retrieval" when the question and table involves domain-specific knowledge, such as "steam-and-leaf plots", "function tables", "tax forms", etc.
+
+- Solution_Generator: This module generates a detailed solution to the question based on the information provided. Normally, we use "Solution_Generator" when the question and table involves simple computation, such as arithmetic operations over a single number.
+
+- Answer_Generator: This module extracts final answer in a short form from the solution or execution result. This module normally follows the "Solution_Generator" or "Problem_Executor" module.
+
+Below are some examples that map the problem to the modules.
+
+Table:
+designer watch | $8,141
+designer coat | $6,391
+
+Question: How much more does a designer watch cost than a designer coat? (unit: $)
+
+Modules: ["Program_Generator", "Program_Verifier", "Program_Executor", "Answer_Generator"]
+
+Table:
+Beverage | Thursday | Friday
+Kickin' Coffee | $9 | $18
+Brenner's Juices | $5 | $8
+Krazy Kola | $13 | $14
+Olde Tyme Cola | $17 | $9
+Fizzy Fun | $12 | $19
+
+Question: Alana, an employee at Hong's Convenience Store, looked at the sales of each of its soda products. Which beverage had lower sales on Thursday, Krazy Kola or Fizzy Fun?
+
+Modules: ["Column_Lookup", "Program_Generator", "Program_Verifier", "Program_Executor", "Answer_Generator"]
+
+Table:
+Ashland | 3:45 A.M. | 12:00 P.M. | 5:15 P.M. | 8:45 P.M. | 10:30 P.M.
+Belmont | 5:00 A.M. | 1:15 P.M. | 6:30 P.M. | 10:00 P.M. | 11:45 P.M.
+Springtown | 6:45 A.M. | 3:00 P.M. | 8:15 P.M. | 11:45 P.M. | 1:30 A.M.
+Oxford | 8:15 A.M. | 4:30 P.M. | 9:45 P.M. | 1:15 A.M. | 3:00 A.M.
+Cedarburg | 9:30 A.M. | 5:45 P.M. | 11:00 P.M. | 2:30 A.M. | 4:15 A.M.
+Oak Grove | 10:15 A.M. | 6:30 P.M. | 11:45 P.M. | 3:15 A.M. | 5:00 A.M.
+Brookfield | 11:30 A.M. | 7:45 P.M. | 1:00 A.M. | 4:30 A.M. | 6:15 A.M.
+Oakdale | 1:00 P.M. | 9:15 P.M. | 2:30 A.M. | 6:00 A.M. | 7:45 A.M.
+Richmond | 2:00 P.M. | 10:15 P.M. | 3:30 A.M. | 7:00 A.M. | 8:45 A.M.
+
+Question: Look at the following schedule. Jaylen just missed the 1.15 P.M. train at Belmont. What time is the next train?
+
+Modules: ["Row_Lookup", "Solution_Generator", "Answer_Generator"]
+
+Table:
+x | y
+10 | 15
+11 | 9
+12 | 2
+
+Question: The table shows a function. Is the function linear or nonlinear?
+
+Modules: ["Knowledge_Retrieval", "Solution_Generator", "Answer_Generator"]
+
+Table:
+Stem | Leaf 
+0 | 1, 4, 7
+1 | 2, 4, 5
+2 | 0, 3
+3 | 
+4 | 0, 1, 5, 8, 9
+5 | 7, 8, 8, 9
+6 | 
+7 | 8, 8
+8 | 3, 7, 7, 8
+9 | 0
+
+Question: A researcher recorded the number of cows on each farm in the county. How many farms have at least 4 cows but fewer than 46 cows?
+
+Modules: ["Row_Lookup", "Table_Verbalizer", "Program_Generator", "Program_Verifier", "Program_Executor", "Answer_Generator"]
+
+Table:
+Stem | Leaf 
+1 | 2, 4
+2 | 2, 4
+3 | 0, 0, 0, 0, 5, 9, 9
+4 | 4, 7
+5 | 4, 7
+6 | 
+7 | 2, 6
+8 | 1, 3
+9 | 0
+
+Question: An architecture student measured the heights of all the buildings downtown. How many buildings are exactly 30 meters tall?
+
+Modules: ["Row_Lookup", "Knowledge_Retrieval", "Program_Generator", "Program_Verifier", "Program_Executor", "Answer_Generator"]
+
+Table:
+ | Fly | Read minds
+Forgetful | 2 | 4
+Lazy | 2 | 2
+
+Question: A creative writing class compiled a list of their favorite superheroes. They listed each superhero's superpower and personality flaw. What is the probability that a randomly selected superhero is lazy and can read minds? Simplify any fractions.
+
+Modules: ["Knowledge_Retrieval", "Program_Generator", "Program_Verifier", "Program_Executor", "Answer_Generator"]
+
+Table:
+Day | Number of balloons
+Tuesday | 9
+Wednesday | 4
+Thursday | 8
+Friday | 4
+Saturday | 8
+Sunday | 10
+Monday | 2
+
+Question: The manager of a party supply store researched how many balloons it sold in the past 7 days. What is the median of the numbers?
+
+Modules: ["Knowledge_Retrieval", "Program_Generator", "Program_Verifier", "Program_Executor", "Answer_Generator"]
+
+Table:
+Park | Number of soccer fields
+Canyon Park | 7
+Windy Hill Park | 3
+Elmhurst Park | 2
+Lighthouse Park | 8
+Madison Park | 4
+
+Question: The parks department compared how many soccer fields there are at each park. What is the range of the numbers?
+
+Modules: ["Solution_Generator", "Answer_Generator"]
+
+Table:
+ | Cat eye frames | Browline frames
+Polarized lenses | 3 | 4
+Regular lenses | 2 | 2
+
+Question: After growing tired of squinting while driving, Dalton went shopping for a pair of sunglasses. He tried on glasses with different frames and lenses. What is the probability that a randomly selected pair of sunglasses has polarized lenses and cat eye frames? Simplify any fractions.
+
+Modules: ["Program_Generator", "Program_Verifier", "Program_Executor", "Answer_Generator"]
+
+Table:
+Sandwich | Number of customers
+Cheese | 300
+Egg salad | 940
+Other | 520
+
+Question: A sandwich shop in Newport polled its customers regarding their favorite sandwiches. What fraction of customers preferred egg salad sandwiches? Simplify your answer.
+
+Modules: ["Program_Generator", "Program_Verifier", "Program_Executor", "Answer_Generator"]
+
+Table:
+Runs scored | Frequency
+0 | 20
+1 | 19
+2 | 2
+3 | 4
+4 | 18
+5 | 3
+
+Question: A statistician analyzed the number of runs scored by players last season. How many players are there in all?
+
+Modules: ["Program_Generator", "Program_Verifier", "Program_Executor", "Answer_Generator"]
+
+Table:
+Name | Number of stickers
+Bernie | 7
+Trent | 7
+Lily | 5
+Roxanne | 5
+Natalie | 5
+
+Question: Some friends compared the sizes of their sticker collections. What is the mode of the numbers?
+
+Modules: ["Knowledge_Retrieval", "Program_Generator", "Program_Verifier", "Program_Executor", "Answer_Generator"]
+
+Table:
+Company | Number of phone calls
+Henderson Co. | 912
+Brave New Day Corporation | 921
+Reardon Corporation | 991
+Tad's Coffee Company | 929
+
+Question: Some companies compared how many phone calls they made. Which company made the most phone calls?
+
+Modules: ["Solution_Generator", "Answer_Generator"]
+
+Table:
+Stem | Leaf 
+5 | 3, 3
+6 | 8, 9
+7 | 2, 4
+8 | 7, 7
+9 | 0, 0, 0
+
+Question: Maria counted the pages in each book on her English class's required reading list. What is the largest number of pages?
+
+Modules: ["Knowledge_Retrieval", "Solution_Generator", "Answer_Generator"]
+
+Table:
+Employee | Pay period |
+Felicia Singer | August 16-31 |
+Total earnings | | $2,110.00
+Federal income tax | $291.66 |
+Other taxes | $161.40 |
+Total taxes | | ?
+Pay after taxes | | ?
+
+Question: Look at Felicia's pay stub. Felicia lives in a state without state income tax. How much payroll tax did Felicia pay in total?
+
+Modules: ["Knowledge_Retrieval", "Table_Verbalizer", "Program_Generator", "Program_Verifier", "Program_Executor", "Answer_Generator"]
+
+Now, you need to act as a policy model, that given a question and a modular set, determines the sequence of modules that can be executed sequentially can solve the question.
+"""

--- a/multi_node/benchmarks/chameleon/prompt_rl.py
+++ b/multi_node/benchmarks/chameleon/prompt_rl.py
@@ -1,0 +1,115 @@
+
+prompt = """
+Read the following question and table. Each row is separated by a newline ('\n') and each column is separated by a vertical bar ('|'). Return the simplified table that only remains the rows that are relevant to the question. If all rows are relevant, or the number of rows are fewer than three, return the original table.
+
+Question: In preparation for graduation, some teachers and students volunteered for the various graduation committees. How many people are on the music committee?
+
+Table:
+Committee | Students | Teachers
+Program | 5 | 17
+Ticket | 20 | 5
+Music | 20 | 15
+Schedule | 15 | 20
+Food | 18 | 2
+
+Simplified Table:
+Committee | Students | Teachers
+Music | 20 | 15
+
+Question: Look at the table. Then answer the question. At a price of $620, is there a shortage or a surplus?
+
+Table:
+Price | Quantity demanded | Quantity supplied
+$590 | 18,400 | 1,400
+$620 | 18,000 | 5,900
+$650 | 17,600 | 10,400
+$680 | 17,200 | 14,900
+$710 | 16,800 | 19,400
+
+Simplified Table:
+Price | Quantity demanded | Quantity supplied
+$620 | 18,000 | 5,900
+
+Question: Look at the following schedule. Amy is at Oakland. If she wants to arrive at Danville at 3.15 P.M., what time should she get on the train?
+
+Table:
+Bloomington | 6:30 A.M. | 6:45 A.M. | 8:45 A.M. | 10:30 A.M. | 11:00 A.M.
+Oakland | 7:45 A.M. | 8:00 A.M. | 10:00 A.M. | 11:45 A.M. | 12:15 P.M.
+Yardley | 9:45 A.M. | 10:00 A.M. | 12:00 P.M. | 1:45 P.M. | 2:15 P.M.
+Middletown | 10:15 A.M. | 10:30 A.M. | 12:30 P.M. | 2:15 P.M. | 2:45 P.M.
+Danville | 11:15 A.M. | 11:30 A.M. | 1:30 P.M. | 3:15 P.M. | 3:45 P.M.
+Castroville | 12:00 P.M. | 12:15 P.M. | 2:15 P.M. | 4:00 P.M. | 4:30 P.M.
+Manchester | 1:30 P.M. | 1:45 P.M. | 3:45 P.M. | 5:30 P.M. | 6:00 P.M.
+
+Simplified Table:
+Oakland | 7:45 A.M. | 8:00 A.M. | 10:00 A.M. | 11:45 A.M. | 12:15 P.M.
+Danville | 11:15 A.M. | 11:30 A.M. | 1:30 P.M. | 3:15 P.M. | 3:45 P.M.
+
+Question: The movie critic liked to count the number of actors in each movie she saw. How many movies had at least 21 actors but fewer than 75 actors?
+
+Table:
+Stem | Leaf
+1 | 5, 7, 7
+2 | 0, 7, 9
+3 | 0, 3
+4 | 
+5 | 2, 4
+6 | 2, 3, 5, 6, 8
+7 | 4, 6
+8 | 2, 4, 8, 9, 9
+
+Simplified Table:
+Stem | Leaf
+2 | 0, 7, 9
+3 | 0, 3
+5 | 2, 4
+6 | 2, 3, 5, 6, 8
+7 | 4, 6
+
+Question: At a candy factory, butterscotch candies were packaged into bags of different sizes. How many bags had exactly 16 butterscotch candies?
+
+Table: 
+Stem | Leaf 
+1 | 2, 4, 6, 7
+2 | 2, 3
+3 | 3, 8
+4 | 1, 2, 3, 8
+5 | 2, 6, 9
+6 | 2, 4, 7
+
+Simplified Table:
+Stem | Leaf 
+1 | 2, 4, 6, 7
+
+Question: What is the total cost for 3 pounds of oysters, 4 pounds of mussels, and 3 pounds of shrimp?
+
+Table: 
+crab meat | $5 per lb
+lobster meat | $12 per lb
+shrimp | $4 per lb
+oysters | $5 per lb
+mussels | $5 per lb
+
+Simplified Table:
+shrimp | $4 per lb
+oysters | $5 per lb
+mussels | $5 per lb
+
+Question: Manuel counted the number of silver beads on each bracelet at Sparrowtown Jewelry, the store where he works. What is the smallest number of silver beads?
+
+Table: 
+Stem | Leaf 
+2 | 0, 2, 4, 7
+3 | 1, 3
+4 | 3
+5 | 3, 4, 7, 9
+6 | 0, 1, 2, 2, 6, 7, 7, 8
+7 | 0, 3, 4, 6, 7, 9
+
+Simplified Table:
+Stem | Leaf 
+2 | 0, 2, 4, 7
+
+
+Read the following question and table. Each row is separated by a newline ('\n') and each column is separated by a vertical bar ('|'). Return the simplified table that only remains the rows that are relevant to the question. If all rows are relevant, or the number of rows are fewer than three, return the original table.
+"""

--- a/multi_node/benchmarks/chameleon/prompt_sg.py
+++ b/multi_node/benchmarks/chameleon/prompt_sg.py
@@ -1,0 +1,127 @@
+
+prompt_choice = """
+Read the following table and then answer a question:
+
+Table:
+Price | Quantity demanded | Quantity supplied
+$895 | 21,000 | 3,400
+$945 | 17,200 | 7,400
+$995 | 13,400 | 11,400
+$1,045 | 9,600 | 15,400
+$1,095 | 5,800 | 19,400
+
+Question: Look at the table. Then answer the question. At a price of $995, is there a shortage or a surplus? Please select from the following options: ['shortage', 'surplus'].
+
+Solution: At the price of $995, the quantity demanded is greater than the quantity supplied. There is not enough of the good or service for sale at that price. So, there is a shortage. The answer is shortage.
+
+Read the following table regarding Ferry fares and then answer a question:
+
+Table:
+Ferry | Bicycle | Car
+Mukilteu-Clinton | $5 | $7
+Seattle-Bremerton | $8 | $12
+Ocracoke | $3 | $15
+Southport-Fort Fisher | $2 | $5
+Fauntleroy-Vashon | $5 | $15
+
+Question: For an economics project, Santiago determined the cost of ferry rides for bicycles and cars. Of the ferries shown, which charges the least for a bicycle? Please select from the following options: ['Ocracoke', 'Mukilteu-Clinton', 'Fauntleroy-Vashon', 'Southport-Fort Fisher'].
+
+Solution: Look at the numbers in the Bicycle column. Find the least number in this column.\n\nThe least number is $2.00, which is in the Southport-Fort Fisher row. The Southport-Fort Fisher ferry charges the least for a bicycle. The answer is Southport-Fort Fisher.
+
+Read the following table and then answer a question:
+
+Table:
+toy guitar | $32.42
+toy piano | $10.55
+model railroad set | $65.51
+toy rocket | $80.93
+chess board | $15.76
+
+Question: Cody has $49.50. Does he have enough to buy a toy guitar and a chess board? Please select from the following options: ['yes', 'no'].
+
+Solution: Add the price of a toy guitar and the price of a chess board:\n\n$32.42 + $15.76 = $48.18\n\n$48.18 is less than $49.50. Cody does have enough money. The answer is yes.
+
+Read the following table regarding Train schedule and then answer a question:
+
+Table:
+Location | Arrive | Depart
+Richmond | 8:05 A.M. | 8:10 A.M.
+Weston | 9:00 A.M. | 9:15 A.M.
+Fairview | 10:15 A.M. | 10:25 A.M.
+Newton | 11:15 A.M. | 11:30 A.M.
+Milford | 12:35 P.M. | 12:45 P.M.
+Greenpoint | 1:45 P.M. | 1:55 P.M.
+Georgetown | 2:35 P.M. | 2:40 P.M.
+
+Question: Look at the following schedule. When does the train arrive at Milford? Please select from the following options: ['12:35 P.M.', '10:15 A.M.', '2:35 P.M.', '8:05 A.M.'].
+
+Solution: Find Milford on the schedule. Find the arrival time for Milford.\n\nMilford: 12:35 P. M. The train arrives at Milford at 12:35 P.M. The answer is 12:35 P.M.
+"""
+
+
+prompt_free = """
+Read the following table regarding Coin collections and then answer a question:
+
+Table:
+Name | Number of coins
+Shelby | 81
+Oliver | 84
+Jamal | 78
+Vince | 81
+Abby | 79
+Farid | 77
+Tara | 85
+Krysta | 83
+
+Question: Some friends discussed the sizes of their coin collections. What is the mean of the numbers?
+
+Solution: Read the numbers from the table.\n\n81, 84, 78, 81, 79, 77, 85, 83\n\nFirst, count how many numbers are in the group.\n\nThere are 8 numbers.\n\nNow add all the numbers together:\n\n81 + 84 + 78 + 81 + 79 + 77 + 85 + 83 = 648\n\nNow divide the sum by the number of numbers:\n\n648 \u00f7 8 = 81\n\nThe mean is 81. The answer is 81.
+
+Read the following table regarding Cans of food collected and then answer a question:
+
+Table:
+Name | Number of cans of food
+Martin | 18
+Cole | 11
+Todd | 24
+Jasper | 4
+Alan | 22
+Percy | 18
+Bridget | 6
+
+Question: Martin's class recorded how many cans of food each student collected for their canned food drive. What is the median of the numbers?
+
+Solution: Read the numbers from the table.\n\n18, 11, 24, 4, 22, 18, 6\n\nFirst, arrange the numbers from least to greatest:\n\n4, 6, 11, 18, 18, 22, 24\n\nNow find the number in the middle.\n\n4, 6, 11, 18, 18, 22, 24\n\nThe number in the middle is 18.\n\nThe median is 18. The answer is 18.
+
+Read the following table regarding Number of houses sold and then answer a question:
+
+Table:
+Town | Number of houses sold
+Seaside | 900
+Summerfield | 600
+Oakdale | 550
+Greenwood | 370
+Fairview | 440
+Other | 420
+
+Question: A real estate agent evaluated the number of houses sold this year in each town in Washington County. What fraction of houses sold in Washington County were in Greenwood? Simplify your answer.
+
+Solution: Find how many houses were sold in Greenwood.\n\n370\n\nFind how many houses were sold in total.\n\n900 + 600 + 550 + 370 + 440 + 420 = 3,280\n\nDivide 370 by 3,280.\n\n\\frac{370}{3,280}\n\nReduce the fraction.\n\n\\frac{370}{3,280} \u2192 \\frac{37}{328}\n\n\\frac{37}{328} of houses were sold in Greenwood. The answer is 37/328.
+
+Read the following table regarding Bricks per building and then answer a question:
+
+Table:
+Stem | Leaf 
+2 | 5, 7, 8
+3 | 
+4 | 
+5 | 8
+6 | 8
+7 | 7
+8 | 1, 1, 9
+9 | 0
+
+Question: The architecture student counted the number of bricks in each building in his neighborhood. How many buildings have at least 20 bricks but fewer than 70 bricks? (Unit: buildings)
+
+Solution: Count all the leaves in the rows with stems 2, 3, 4, 5, and 6.\n\nYou counted 5 leaves, which are blue in the stem-and-leaf plot above. 5 buildings have at least 20 bricks but fewer than 70 bricks. The answer is 5.
+"""

--- a/multi_node/benchmarks/chameleon/prompt_tv.py
+++ b/multi_node/benchmarks/chameleon/prompt_tv.py
@@ -1,0 +1,84 @@
+
+prompt = """
+Read the following question and table. Write a textual description of the table. The description should keep the critical information in the table for answering the question. The description should not answer the question.
+
+Question: In preparation for graduation, some teachers and students volunteered for the various graduation committees. How many people are on the music committee?
+
+Table:
+Committee | Students | Teachers
+Program | 5 | 17
+Ticket | 20 | 5
+Music | 20 | 15
+Schedule | 15 | 20
+Food | 18 | 2
+
+Table description: The table shows the number of students and teachers on each of the four graduation committees: Program, Ticket, Music, and Schedule. The Music committee has 20 students and 15 teachers.
+
+Question: Omar has two dogs, Sprinkles and Champ. He is concerned because Sprinkles keeps eating Champ's food. Omar asks their vet how much each dog's weight has changed since their last visit. Which dog's weight has changed the most?
+
+Table:
+Dog | Weight change (oz.)
+Sprinkles | 5
+Champ | -6
+
+Table description: The table shows the weight change of two dogs, Sprinkles and Champ, since their last visit to the vet. Sprinkles' weight has increased by 5 ounces, while Champ's weight has decreased by 6 ounces.
+
+Question: The architecture student counted the number of bricks in each building in his neighborhood. How many buildings have at least 20 bricks but fewer than 70 bricks?
+
+Table:
+Stem | Leaf
+2 | 5, 7, 8
+3 | 
+4 | 
+5 | 8
+6 | 8
+7 | 7
+8 | 1, 1, 9
+9 | 0
+
+Table description: The table shows the number of bricks in the architecture student's neighborhood in each building. The numbers of bricks are 25, 27, 28, 58, 68, 77, 81, 81, 89, and 90.
+
+Question: Alana, an employee at Hong's Convenience Store, looked at the sales of each of its soda products. Which beverage had lower sales on Thursday, Krazy Kola or Fizzy Fun?
+
+Table:
+Beverage | Thursday | Friday
+Kickin' Coffee | $9 | $18
+Brenner's Juices | $5 | $8
+Krazy Kola | $13 | $14
+Olde Tyme Cola | $17 | $9
+Fizzy Fun | $12 | $19
+
+Table description: The table shows the sales of five beverages at Hong's Convenience Store on Thursday and Friday. Krazy Kola had sales of $13 on Thursday, while Fizzy Fun had sales of $12 on Thursday.
+
+Question: Look at the following schedule. Lee just missed the 1.00 P.M. train at Snowy Mountain. What time is the next train?
+
+Table:
+Snowy Mountain | 2:30 A.M. | 4:30 A.M. | 1:00 P.M. | 4:00 P.M. | 12:00 A.M.
+Comfy Pillows Resort | 3:15 A.M. | 5:15 A.M. | 1:45 P.M. | 4:45 P.M. | 12:45 A.M.
+Magician Village | 3:45 A.M. | 5:45 A.M. | 2:15 P.M. | 5:15 P.M. | 1:15 A.M.
+Floral Gardens | 4:30 A.M. | 6:30 A.M. | 3:00 P.M. | 6:00 P.M. | 2:00 A.M.
+
+Table description:  The table shows the train schedule from Snowy Mountain to four other destinations: Comfy Pillows Resort, Magician Village, Floral Gardens, and back to Snowy Mountain. The trains depart from Snowy Mountain at 2:30 A.M., 4:30 A.M., 1:00 P.M., 4:00 P.M., and 12:00 A.M.
+
+Question: A researcher recorded the number of cows on each farm in the county. How many farms have at least 4 cows but fewer than 46 cows?
+
+Table:
+Stem | Leaf 
+0 | 1, 4, 7
+1 | 2, 4, 5
+2 | 0, 3
+4 | 0, 1, 5, 8, 9
+
+Table description: The table shows the number of cows on each farm in the county. The numbers of cows are 1, 4, 7, 12, 14, 15, 20, 23, 40, 41, 45, 48, and 49.
+
+Question: A dietitian noted the number of apples eaten by his clients last week. How many clients ate more than 1 apple last week?
+
+Table:
+Apples eaten | Frequency
+2 | 12
+3 | 4
+
+Table description: The table shows the number of apples eaten by the dietitian's clients last week. There were 12 clients who ate 2 apples and 4 clients who ate 3 apples.
+
+Read the following question and table. Write a textual description of the table. The description should keep the critical information in the table for answering the question. The description should not answer the question.
+"""

--- a/multi_node/benchmarks/toolqa/__init__.py
+++ b/multi_node/benchmarks/toolqa/__init__.py
@@ -1,0 +1,4 @@
+"""Prompts of the ToolQA benchmark."""
+
+from .prompts import REACT_INSTRUCTION
+from .fewshots import TOOLQA_EASY8, TOOLQA_HARD3

--- a/multi_node/benchmarks/toolqa/fewshots.py
+++ b/multi_node/benchmarks/toolqa/fewshots.py
@@ -1,0 +1,142 @@
+TOOLQA_EASY8 = """Question: How many extra minutes did the DL1575 flight take from ATL to MCO on 2022-01-12?
+Thought 1: This is a question related to flights. We need to load the flights database.
+Action 1: LoadDB[flights]
+Observation 1: We have successfully loaded the flights database, including the following columns: FlightDate, Airline, Origin, Dest, Cancelled, Diverted, CRSDepTime, DepTime, DepDelayMinutes, DepDelay, ArrTime, ArrDelayMinutes, AirTime, CRSElapsedTime, ActualElapsedTime, Distance, Year, Quarter, Month, DayofMonth, DayOfWeek, Marketing_Airline_Network, Operated_or_Branded_Code_Share_Partners, DOT_ID_Marketing_Airline, IATA_Code_Marketing_Airline, Flight_Number_Marketing_Airline, Operating_Airline, DOT_ID_Operating_Airline, IATA_Code_Operating_Airline, Tail_Number, Flight_Number_Operating_Airline, OriginAirportID, OriginAirportSeqID, OriginCityMarketID, OriginCityName, OriginState, OriginStateFips, OriginStateName, OriginWac, DestAirportID, DestAirportSeqID, DestCityMarketID, DestCityName, DestState, DestStateFips, DestStateName, DestWac, DepDel15, DepartureDelayGroups, DepTimeBlk, TaxiOut, WheelsOff, WheelsOn, TaxiIn, CRSArrTime, ArrDelay, ArrDel15, ArrivalDelayGroups, ArrTimeBlk, DistanceGroup, DivAirportLandings
+Thought 2: We need to filter the information related to the query.
+Action 2: FilterDB[Flight_Number_Marketing_Airline=1575, FlightDate=2022-01-12, Origin=ATL, Dest=MCO]
+Observation 2: We have successfully filtered the data (1 row).
+Thought 3: We then need to know the departure delayed time.
+Action 3: GetValue[DepDelay]
+Observation 3: -7.0
+Thought 4: We then need to know the arrival delayed time.
+Action 4: GetValue[ArrDelay]
+Observation 4: -17.0
+Thought 5: To compute the extra minutes, we need to subtract the departure delayed time from the arrival delayed time.
+Action 5: Calculate[(-17)-(-7)]
+Observation 5: -10
+Thought 6: After calculation, we know that the answer is -10.
+Action 6: Finish[-10]
+
+Question: Michael had 58 golf balls. On tuesday, he lost 23 golf balls. On wednesday, he lost 2 more. How many golf balls did he have at the end of wednesday?
+Thought 1: Maybe I can write a python program to solve this problem.
+Action 1: PythonInterpreter[# solution in Python:
+def solution():
+    # Michael had 58 golf balls. On tuesday, he lost 23 golf balls. On wednesday, he lost 2 more. How many golf balls did he have at the end of wednesday?
+    golf_balls_initial = 58
+    golf_balls_lost_tuesday = 23
+    golf_balls_lost_wednesday = 2
+    golf_balls_left = golf_balls_initial - golf_balls_lost_tuesday - golf_balls_lost_wednesday
+    result = golf_balls_left
+    return result]
+Observation 1: 33
+Thought 2: After execution of Python Code, we know that the answer is 33.
+Action 2: Finish[33]
+
+Question: What is the corresponding Mean_IoU score of the FRRN method on Cityscapes dataset for Semantic_Segmentation task?
+Thought 1: The question is asking some performance information about Mean_IoU score of the FRRN method on Cityscapes dataset for Semantic_Segmentation task, we need to retrieve some useful information from the scirex database.
+Action 1: RetrieveScirex[Mean_IoU score of the FRRN method on Cityscapes dataset for Semantic_Segmentation task]
+Observation 1: section : Abstract Semantic image segmentation is an essential component of modern autonomous driving systems , as an accurate understanding of the surrounding scene is crucial to navigation and action planning . Current state - of - the - art approaches in semantic image segmentation rely on pretrained networks that were initially developed for classifying images as a whole . While these networks exhibit outstanding recognition performance ( i.e. , what is visible ? ) , they lack localization accuracy ( i.e. , where precisely is something located ? ) . Therefore , additional processing steps have to be performed in order to obtain pixel - accurate segmentation masks at the full image resolution . To alleviate this problem we propose a novel ResNet - like architecture that exhibits strong localization and recognition performance . We combine multi - scale context with pixel - level accuracy by using two processing streams within our network : One stream carries information at the full image resolution , enabling precise adherence to segment boundaries . The other stream undergoes a sequence of pooling operations to obtain robust features for recognition . The two streams are coupled at the full image resolution using residuals . Without additional processing steps and without pretraining , our approach achieves an intersection - over - union score of 71.8 % on the Cityscapes dataset .
+Thought 2: As the approach achieves an intersection - over - union score of 71.8 % on the Cityscapes dataset, the answer should be 71.8%.
+Action 2: Finish[71.8%]
+
+Question: When was the paper Learning the Principle of Least Action with Reinforcement Learning. published?
+Thought 1: The question is asking some basic information of a dblp paper. We need to load the DBLP graph.
+Action 1: LoadGraph[dblp]
+Observation 1: DBLP graph is loaded.
+Thought 2: The question is asking the published date of a paper, we need to check the node from the PaperNet in DBLP graph.
+Action 2: NodeCheck[PaperNet, Learning the Principle of Least Action with Reinforcement Learning.]
+Observation 2: {'title': 'Learning the Principle of Least Action with Reinforcement Learning.', 'year': 2021, 'venue': {'raw': 'AAAI Spring Symposium - MLPS'}, 'n_citation': 0, 'keywords': [], 'doc_type': 'Conference', 'page_start': '', 'page_end': ''}
+Thought 3: The published date of the paper is 2021.
+Action 3: Finish[2021]
+
+Question: How many collaborators does Chao Zhang have in the DBLP graph?
+Thought 1: The question is asking the number of collaborators of a person, we need load the DBLP graph.
+Action 1: LoadGraph[dblp]
+Observation 1: DBLP graph is loaded.
+Thought 2: The question is asking the collaborators of a person, we need to check the neighboring nodes from the AuthorNet in DBLP graph.
+Action 2: NeighbourCheck[AuthorNet, Chao Zhang]
+Observation 2: ['YUHUI YUAN', 'Rao Fu', 'Lang Huang', 'Weihong Lin', 'X Chen', 'Jingdong Wang']
+Thought 3: The number of collaborators of Chao Zhang is 6.
+Action 3: Finish[6]
+
+Question: How many papers does Chao Zhang and Weihong Lin have in common in the DBLP graph?
+Thought 1: The question is asking the number of common papers of two persons, we need load the DBLP graph.
+Action 1: LoadGraph[dblp]
+Observation 1: DBLP graph is loaded.
+Thought 2: The question is asking the common papers of two persons, we need to check the edges between them from the PaperNet in DBLP graph.
+Action 2: EdgeCheck[PaperNet, Chao Zhang, Weihong Lin]
+Observation 2: {'weight': 1, 'papers': ['HRFormer: High-Resolution Vision Transformer for Dense Predict.'], 'n_citation': [95]}
+Thought 3: The number of common papers of Chao Zhang and Weihong Lin is 1.
+
+Question: Where did Stephen's Opera performance take place?
+Thought 1: The question is asking the location of Stephen's Opera performance from agenda.
+Action 1: RetrieveAgenda[Stephen's Opera performance]
+Observation 1: On January 29, 2022, there will be an opera performance at the Lyric Opera House, featuring Stephen. The show will start at 7:00 PM and end at 9:00 PM. It promises to be a wonderful evening of beautiful music and powerful performances in a stunning venue. Come and experience the magic of opera at its finest!
+Thought 2: The event happened in Lyric Opera.
+Action 2: Finish[Lyric Opera]
+
+Question: What was the trading volume of coffee on 2000-01-14?
+Thought 1: Maybe I can write a SQL query to solve this problem.
+Action 1: SQLInterpreter(SELECT Volume FROM coffee.coffee_data WHERE Date = '2000-01-14';
+Observation 1: Volume: 10115
+Thought 2: The volume of coffee on 2000-01-14 is 10115.
+Action 2: Finish[10115]
+"""
+
+TOOLQA_HARD3 = """Question: What is the average airtime of the flights from PHX to LGA host by Spirit Air Lines?
+Thought 1: This is a question related to flights. We need to load the flights database.
+Action 1: LoadDB[flights]
+Observation 1: We have successfully loaded the flights database, including the following columns: FlightDate, Airline, Origin, Dest, Cancelled, Diverted, CRSDepTime, DepTime, DepDelayMinutes, DepDelay, ArrTime, ArrDelayMinutes, AirTime, CRSElapsedTime, ActualElapsedTime, Distance, Year, Quarter, Month, DayofMonth, DayOfWeek, Marketing_Airline_Network, Operated_or_Branded_Code_Share_Partners, DOT_ID_Marketing_Airline, IATA_Code_Marketing_Airline, Flight_Number_Marketing_Airline, Operating_Airline, DOT_ID_Operating_Airline, IATA_Code_Operating_Airline, Tail_Number, Flight_Number_Operating_Airline, OriginAirportID, OriginAirportSeqID, OriginCityMarketID, OriginCityName, OriginState, OriginStateFips, OriginStateName, OriginWac, DestAirportID, DestAirportSeqID, DestCityMarketID, DestCityName, DestState, DestStateFips, DestStateName, DestWac, DepDel15, DepartureDelayGroups, DepTimeBlk, TaxiOut, WheelsOff, WheelsOn, TaxiIn, CRSArrTime, ArrDelay, ArrDel15, ArrivalDelayGroups, ArrTimeBlk, DistanceGroup, DivAirportLandings
+Thought 2: We need to filter the information related to the query.
+Action 2: FilterDB[Origin=PHX, Dest=ATL, Airline=Spirit Air Lines]
+Observation 2: We have successfully filtered the data (16 rows).
+Thought 2: We then obtain all the AirTime values of filtered records.
+Action 2: GetValue[AirTime]
+Observation 2: [247.0, 253.0, 230.0, 264.0, 254.0, 275.0, 227.0, 258.0, 245.0, 253.0, 242.0, nan, 229.0, nan, 259.0, 253.0]
+Thought 3: We then calculate the average of the values. NaN values are ignored.
+Action 3: Calculate(mean(247.0, 253.0, 230.0, 264.0, 254.0, 275.0, 227.0, 258.0, 245.0, 253.0, 242.0, 229.0, 259.0, 253.0))
+Observation 3: 249.214
+Thought 4: The average airtime of the flights from PHX to LGA host by Spirit Air Lines is 249.2.
+Action 4: Finish[249.2]
+
+Question: Can you recommend a Guamanian business with the highest star rating within a 5-mile radius of 6830 Rising Sun Ave?
+Thought 1: This is a question related to business. We need to load the yelp database.
+Action 1: LoadDB[yelp]
+Observation 1: We have successfully loaded the yelp database, including the following columns: business_id, name, address, city, state, postal_code, latitude, longitude, stars, review_count, is_open, attributes, categories, hours
+Thought 2: Maybe we can write SQL code to obtain the latitude and longitude of the address.
+Action 2: SQLInterpreter[SELECT latitude, longitude FROM yelp.yelp_data WHERE address='6830 Rising Sun Ave']  
+Observation 2: latitude: 40.05555, longitude: -75.090723 
+Thought 3: Maybe we can write another python code to calculate the coordinates range of 5-mile radius.
+Action 3: import geopy\nimport geopy.distance\nlatitude = 40.05555\nlongitude = -75.090723\n_, lo_max, _ = geopy.distance.distance(kilometers=5).destination(point=(latitude, longitude), bearing=90)\n_, lo_min, _ = geopy.distance.distance(kilometers=5).destination(point=(latitude, longitude), bearing=270)\nla_max, _, _ = geopy.distance.distance(kilometers=5).destination(point=(latitude, longitude), bearing=0)\nla_min, _, _ = geopy.distance.distance(kilometers=5).destination(point=(latitude, longitude), bearing=180)\nans = (la_max, la_min, lo_max, lo_min)
+Observation 3: (40.10058038657396, 40.010519262352226, -75.03212327463275, -75.14932272536724)
+Thought 4: We then filter the information related to the query in the yelp database.
+Action 4: FilterDB[latitude>=40.010519262352226, longitude>=-75.14932272536724, latitude<=40.10058038657396, longitude<=-75.03212327463275, categories=Guamanian]
+Observation 4: We have successfully filtered the data (2 rows).
+Thought 5: We then obtain all the stars values of filtered records.
+Action 5: GetValue[stars]
+Observation 5: [4.0, 4.5]
+Thought 6: The highest star rating is 4.5. Select the business with the highest star rating.
+Action 6: FilterDB[stars=4.5]
+Observation 6: We have successfully filtered the data (1 row).
+Thought 7: Get the corresponding name.
+Action 7: GetValue[name]
+Observation 7: Damaso Painting
+Thought 8: The business with the highest star rating is Damaso Painting.
+Action 8: Finish[Damaso Painting]
+
+Question: What venue does Chao Zhang with his collarborator publish paper on?
+Thought 1: This is a question related to DBLP. We need to load the DBLP graph.
+Action 1: LoadGraph[dblp]
+Observation 1: DBLP graph is loaded.
+Thought 2: We need to check the neighbouring nodes of Chao Zhang in AuthorNet.
+Action 2: NeighbourCheck[AuthorNet, Chao Zhang]
+Observation 2: Weihong Lin
+Thought 3: We need to check the between Chao Zhang and Weihong Lin to check their collaboration.
+Action 3: EdgeCheck[AuthorNet, Chao Zhang, Weihong Lin]
+Observation 3: {'weight': 1, 'papers': ['HRFormer: High-Resolution Vision Transformer for Dense Predict.'], 'n_citation': [95]}
+Thought 4: We need to check the paper detail in the node feature from PaperNet they published.
+Action 4: NodeCheck[PaperNet, HRFormer: High-Resolution Vision Transformer for Dense Predict.]
+Observation 4: {'title': 'HRFormer: High-Resolution Vision Transformer for Dense Predict.', 'year': 2021, 'venue': {'raw': 'AAAI Spring Symposium - MLPS'}, 'n_citation': 0, 'keywords': [], 'doc_type': 'Conference', 'page_start': '', 'page_end': ''}
+Thought 5: The paper is published on AAAI Spring Symposium - MLPS.
+Action 5: Finish[AAAI Spring Symposium - MLPS]
+"""

--- a/multi_node/benchmarks/toolqa/prompts.py
+++ b/multi_node/benchmarks/toolqa/prompts.py
@@ -1,0 +1,19 @@
+REACT_INSTRUCTION = """Solve a question answering task with interleaving Thought, Action, Observation steps. Thought can reason about the current situation, and Action can be 13 types: 
+(1) Calculate[formula], which calculates the formula and returns the result.
+(2) RetrieveAgenda[keyword], which retrieves the agenda related to keyword.
+(3) RetrieveScirex[keyword], which retrieves machine learning papers' paragraphs related to keyword.
+(4) LoadDB[DBName], which loads the database DBName and returns the database. The DBName can be one of the following: flights/coffee/airbnb/yelp.
+(5) FilterDB[condition], which filters the database DBName by the column column_name the relation (e.g., =, >, etc.) and the value value, and returns the filtered database.
+(6) GetValue[column_name], which returns the value of the column column_name in the database DBName.
+(7) LoadGraph[GraphName], which loads the graph GraphName and returns the graph. The GraphName can be one of the following: PaperNet/AuthorNet.
+(8) NeighbourCheck[GraphName, Node], which lists the neighbours of the node Node in the graph GraphName and returns the neighbours. 
+(9) NodeCheck[GraphName, Node], which returns the detailed attribute information of Node. 
+(10) EdgeCheck[GraphName, Node1, Node2], which returns the detailed attribute information of the edge between Node1 and Node2. 
+(11) SQLInterpreter[SQL], which interprets the SQL query SQL and returns the result.
+(12) PythonInterpreter[Python], which interprets the Python code Python and returns the result.
+(13) Finish[answer], which returns the answer and finishes the task.
+You may take as many steps as necessary.
+Here are some examples:
+{examples}
+(END OF EXAMPLES)
+Question: {question}{scratchpad}"""


### PR DESCRIPTION
This PR adds three dataloader, including
- Agent: Chameleon with TabMWP dataset, 9 system prompts
- Agent: CREATOR with MATH dataset, 3 system prompts
- Tool: ToolQA, 2 system prompts

The data path for each of these datasets should be:
- Chameleon with TabMWP: [results/tabmwp/chameleon_gpt4_test_cache.jsonl](https://github.com/lupantech/chameleon-llm/blob/main/results/tabmwp/chameleon_gpt4_test_cache.jsonl)
- CREATOR with MATH: [MATH](https://github.com/qiancheng0/CREATOR/tree/main/MATH)
- ToolQA: [data/questions](https://github.com/night-chen/ToolQA/tree/main/data/questions)