### PR TITLE
Fix tensor parallel vllm tp size initialization for vllm 0.6.3.post1

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ CLI Configuration
 
 ## Citation And Acknowledgment
 The code is forked of sglang
+```
+@inproceedings{
+srivatsa2025preble,
+title={Preble: Efficient Distributed Prompt Scheduling for {LLM} Serving},
+author={Vikranth Srivatsa and Zijian He and Reyna Abhyankar and Dongming Li and Yiying Zhang},
+booktitle={The Thirteenth International Conference on Learning Representations},
+year={2025},
+}
+```
 
 # pypi build and install instructions
 Currently uploaded at:
@@ -78,7 +87,13 @@ Currently uploaded at:
 ```python3 -m pip install --index-url https://test.pypi.org/simple/ preble```
 
  
+# Test running the server in isolation
+Launch the server in isolation to help debug issues
+```
+python -m sglang.launch_server --model-path mistralai/Mistral-7B-v0.1 --cuda-devices 0 --tp-size 2 
+```
 
-License
+# License
 
 This project is licensed under the Apache 2.0 License. See the LICENSE file for details.
+

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 srt = ["aiohttp", "fastapi", "psutil", "rpyc", "torch", "uvloop", "uvicorn",
-       "zmq", "vllm>=0.4.2", "interegular", "pydantic", "pillow", "packaging", "huggingface_hub", "hf_transfer", "outlines>=0.0.34"]
+       "zmq", "vllm==0.6.3.post1", "interegular", "pydantic", "pillow", "packaging", "huggingface_hub", "hf_transfer", "outlines==0.0.34"]
 openai = ["openai>=1.0", "numpy", "tiktoken"]
 anthropic = ["anthropic>=0.20.0", "numpy"]
 all = ["sglang[srt]", "sglang[openai]", "sglang[anthropic]"]

--- a/python/sglang/srt/managers/router/manager.py
+++ b/python/sglang/srt/managers/router/manager.py
@@ -37,10 +37,14 @@ class RouterManager:
         self.send_to_migration_target = context.socket(zmq.PUSH)
         self.recv_from_migration_source = context.socket(zmq.PULL)
         self.recv_from_migration_source.bind(f'tcp://0.0.0.0:{port_args.migrate_port}')
-
-        if model_client.model_server.enable_iterative_eviction:
+        
+        if model_client.tp_size > 1:
+            if any(client.enable_iterative_eviction for client in model_client.model_servers):
+                self.send_to_sched = context.socket(zmq.PUSH)
+                self.send_to_sched.connect("tcp://127.0.0.1:10340")
+        elif model_client.model_server.enable_iterative_eviction:
             self.send_to_sched = context.socket(zmq.PUSH)
-            self.send_to_sched.connect(f"tcp://127.0.0.1:10340")
+            self.send_to_sched.connect("tcp://127.0.0.1:10340")
 
         # self.recv_from_sched = context.socket(zmq.PULL)
         # self.recv_from_sched.bind(f"tcp://127.0.0.1:10340")

--- a/python/sglang/srt/managers/router/model_runner.py
+++ b/python/sglang/srt/managers/router/model_runner.py
@@ -11,7 +11,7 @@ import os
 
 import numpy as np
 import torch
-from vllm.distributed import initialize_model_parallel
+from vllm.distributed import initialize_model_parallel, init_distributed_environment
 from vllm.model_executor.layers.quantization.awq import AWQConfig
 from vllm.model_executor.layers.quantization.gptq import GPTQConfig
 from vllm.model_executor.layers.quantization.marlin import MarlinConfig
@@ -316,16 +316,17 @@ class ModelRunner:
 
         if not self.simulate:
             # Init torch distributed
-            # logger.info(f'model {self.gpu_config.gpu_id}, Rank {self.tp_rank} setup')
+            # print()
+            os.environ["CUDA_VISIBLE_DEVICES"] = "0,1"
             torch.cuda.set_device(self.tp_rank)
-            torch.distributed.init_process_group(
+            init_distributed_environment(
                 backend="nccl",
                 world_size=self.tp_size,
                 rank=self.tp_rank,
-                init_method=f"tcp://127.0.0.1:{self.nccl_port}",
+                distributed_init_method=f"tcp://127.0.0.1:{self.nccl_port}",
             )
             initialize_model_parallel(tensor_model_parallel_size=self.tp_size)
-
+            print("Rank %d: torch distributed initialized" % self.tp_rank)
             total_gpu_memory = get_available_gpu_memory(
                 self.tp_rank, distributed=self.tp_size > 1
             ) * (1 << 30)

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -209,7 +209,11 @@ def launch_server(server_args: ServerArgs, pipe_finish_writer, gpu_config, model
     )
 
     if server_args.cuda_devices:
-        os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(d) for d in server_args.cuda_devices)
+        all_cuda_devices = []
+        for device_start in server_args.cuda_devices:
+            for rank in range(server_args.tp_size):
+                all_cuda_devices.append(int(device_start) + rank)
+        os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(d) for d in all_cuda_devices)
         logger.info(f"Set CUDA_VISIBLE_DEVICES to {os.environ['CUDA_VISIBLE_DEVICES']}")
 
     logging.basicConfig(


### PR DESCRIPTION
VLLM updated the tensor parallel initialization method in their later versions. 

Should fix the error in: #80

Tested via running:
```
python -m sglang.launch_server --model-path mistralai/Mistral-7B-v0.1 --tp-size 2 --cuda-devices 0
```

```
preble deploy_and_run --devices 0, --tp-size 2
```